### PR TITLE
Export IconContextProps

### DIFF
--- a/bin/assemble.js
+++ b/bin/assemble.js
@@ -162,7 +162,7 @@ export default ${name};
 function generateExports() {
   let indexString = `\
 /* GENERATED FILE */
-export { Icon, IconProps, IconContext } from "./lib";
+export { Icon, IconProps, IconContext, IconContextProps } from "./lib";
 
 `;
   for (let key in icons) {


### PR DESCRIPTION
Currently you cannot create the context props easily outside of the provider, so you basically end up copying the types from `lib`.